### PR TITLE
chore/death_record:replace integer with number

### DIFF
--- a/_definitions.yaml
+++ b/_definitions.yaml
@@ -57,7 +57,7 @@ file_name:
         $ref: "_terms.yaml#/file_name"
 
 file_size:
-    type: integer
+    type: number
     term: 
         $ref: "_terms.yaml#/file_size"
 

--- a/gdcdictionary/schemas/_definitions.yaml
+++ b/gdcdictionary/schemas/_definitions.yaml
@@ -87,7 +87,7 @@ file_name:
         $ref: "_terms.yaml#/file_name"
 
 file_size:
-    type: integer
+    type: number
     term:
         $ref: "_terms.yaml#/file_size"
 

--- a/gdcdictionary/schemas/_terms.yaml
+++ b/gdcdictionary/schemas/_terms.yaml
@@ -980,7 +980,7 @@ ldh_level_at_diagnosis:
     The 2 decimal place numeric laboratory value measured, assigned or computed related to the
     assessment of lactate dehydrogenase in a specimen.
   termDef:
-    term: Laboratory Procedure Lactate Dehydrogenase Result Integer::2 Decimal Place Value
+    term: Laboratory Procedure Lactate Dehydrogenase Result number::2 Decimal Place Value
     source: caDSR
     cde_id: 2798766
     cde_version: 1.0

--- a/gdcdictionary/schemas/death_record.yaml
+++ b/gdcdictionary/schemas/death_record.yaml
@@ -134,17 +134,17 @@ properties:
   interval_to_death_first_cause:
     description: >
       Onset to Death interval from first underlying cause of death to death (hours). (GTEx) 
-    type: integer
+    type: number
 
   interval_to_death_immediate_cause:
     description: >
       Onset to Death Interval from immediate cause of death to death (hours). (GTEx)
-    type: integer
+    type: number
 
   interval_to_death_last_cause:
     description: >
       Onset to Death Interval from last underlying cause of death to death (hours). (GTEx) 
-    type: integer
+    type: number
 
   last_cause_of_death:
     description: >
@@ -184,7 +184,7 @@ properties:
   hours_in_ventilator:
     description: >
       Period of time that donor was assisted by a medical device that facilitates breathing prior to death. (GTEx)
-    type: integer
+    type: number
 
   on_ventilator_immediate:
     description: >

--- a/gdcdictionary/schemas/exposure.yaml
+++ b/gdcdictionary/schemas/exposure.yaml
@@ -62,7 +62,7 @@ properties:
   smoke_number:
     description: >
       Units smoked during Smoke Period (SMKPRD). (GTEx)
-    type: integer
+    type: number
 
   smoke_period:
     description: >
@@ -123,7 +123,7 @@ properties:
   drink_number:
     term:
       $ref: "_terms.yaml#/drink_number"
-    type: integer
+    type: number
 
   drink_period:
     description: >
@@ -133,7 +133,7 @@ properties:
   drink_years:
     description: >
       Number of years the Donor drank. (GTEx)
-    type: integer
+    type: number
 
   drink_comments:
     description: >

--- a/gdcdictionary/schemas/imaging_file.yaml
+++ b/gdcdictionary/schemas/imaging_file.yaml
@@ -99,7 +99,7 @@ properties:
   series_instance_number:
     description: >
       order number for this image or other content.
-    type: integer
+    type: number
 
   cases:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/medical_history.yaml
+++ b/gdcdictionary/schemas/medical_history.yaml
@@ -673,7 +673,7 @@ properties:
   chdh_time:
     description: >
       Time to hard CHD or Last Follow-up in days
-    type: integer
+    type: number
 
   chda:
     description: >
@@ -683,7 +683,7 @@ properties:
   chda_time:
     description: >
       Time to all CHD or Lat Follow-up in days
-    type: integer
+    type: number
 
   cvdh:
     description: >
@@ -693,7 +693,7 @@ properties:
   cvdh_time:
     description: >
       Time to hard CVD or Last Follow-up in days
-    type: integer
+    type: number
 
   cvda:
     description: >
@@ -703,7 +703,7 @@ properties:
   cvda_time:
     description: >
       Time to all CVD or Last Follow-up in days
-    type: integer
+    type: number
 
   prostate_cancer:
     description: >

--- a/gdcdictionary/schemas/read_group.yaml
+++ b/gdcdictionary/schemas/read_group.yaml
@@ -235,7 +235,7 @@ properties:
     type: boolean
 
   read_length:
-    type: integer
+    type: number
 
   read_group_name:  # it may be good to assign UUID to read group
     description: "Read Group Name"

--- a/gdcdictionary/schemas/read_group_qc.yaml
+++ b/gdcdictionary/schemas/read_group_qc.yaml
@@ -58,7 +58,7 @@ properties:
   cumulative_gap_length:
     description: >
       Cumulative Gap Length: Cumulative length of gap regions
-    type: integer
+    type: number
 
   encoding:
     term:
@@ -73,7 +73,7 @@ properties:
   estimated_library_size:
     description: >
       Estimated library size: Number of expected fragments based on the total reads and duplication rate assuming a Poisson distribution.
-    type: integer
+    type: number
 
   fastq_name:
     term:
@@ -86,7 +86,7 @@ properties:
   maximun_read_length:
     description: >
       Read Length: maximum detected read length found
-    type: integer
+    type: number
 
   mean_coefficient_of_variation_of_base_covarage:
     description: >
@@ -101,12 +101,12 @@ properties:
   mean_frament_length:
     description: >
       Fragment Length Mean: The fragment length is the distance between the start of an upstream read and the end of the downstream pair mate
-    type: integer
+    type: number
 
   number_of_gaps:
     description: >
       Number of Gaps: Number of regions with >=5 bases with zero coverage
-    type: integer
+    type: number
 
   overrepresented_sequences:
     $ref: "_definitions.yaml#/qc_metrics_state"
@@ -178,7 +178,7 @@ properties:
   percent_gc_content:
     term:
       $ref: "_terms.yaml#/percent_gc_content"
-    type: integer
+    type: number
     minimum: 0
     maximum: 100
 
@@ -234,36 +234,36 @@ properties:
     description: >
       Fragment Length StdDev: The fragment length is the distance between the start of an upstream read 
       and the end of the downstream pair mate
-    type: integer
+    type: number
 
   total_aligned_reads:
     description: "The total number of reads with at least one reported alignment."
-    type: integer
+    type: number
 
   total_sequences:
     term:
       $ref: "_terms.yaml#/total_sequences"
-    type: integer
+    type: number
 
   total_alternative_aligment:
     description: >
       Alternative Aligments: duplicate read entries providing alternative coordinates
-    type: integer
+    type: number
 
   total_chimeric_pairs:
     description: >
       Chimeric Pairs: Pairs whose mates map to different genes
-    type: integer
+    type: number
 
   total_end1_in_antisense:
     description: >
       End 1 Antisense: Number of End 1 reads that were sequenced in the antisense direction
-    type: integer
+    type: number
 
   total_end1_in_sense:
     description: >
       End 1 Sense: Number of End 1 reads that were sequenced in the sense direction
-    type: integer
+    type: number
 
   total_end2_in_antisense:
     description: >
@@ -273,47 +273,47 @@ properties:
   total_end2_in_sense:
     description: >
       End 2 Sense: Number of End 2 reads that were sequenced in the sense direction
-    type: integer
+    type: number
 
   total_genes_detected:
     description: >
       Genes Detected: Total number of genes with at least 5 exon mapping reads
-    type: integer
+    type: number
 
   total_mapped_pairs:
     description: >
       Mapped Pairs:Total number of pairs for which both ends map
-    type: integer
+    type: number
 
   total_reads_lacking_pair_mate:
     description: >
       Unpaired Reads: number of reads lacking a pair mate
-    type: integer
+    type: number
 
   total_reads_span_exon_exon_boundary:
     description: >
       Split Reads: The number of reads that span an exon-exon boundary
-    type: integer
+    type: number
 
   total_transcript_detected:
     description: >
       Transcripts Detected: Total number of transcripts with at least 5 exon mapping reads
-    type: integer
+    type: number
 
   total_transcript_with_5_sequenced:
     description: >
       Number Covered 5': The number of transcripts that have at least one read in their 5' end
-    type: integer
+    type: number
 
   total_unique_aligned_reads:
     description: >
       Mapped Unique: Number of reads that were aligned and did not have duplicate flags
-    type: integer
+    type: number
 
   total_vendor_check_failed_reads:
     description: >
       Failed Vendor QC Check: reads having been designated as failed by the sequencer
-    type: integer
+    type: number
 
   read_groups:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/sample.yaml
+++ b/gdcdictionary/schemas/sample.yaml
@@ -144,7 +144,7 @@ properties:
   hours_to_sample_procurement:
     description: >
       Time a sample spent in the PAXgene fixative
-    type: integer
+    type: number
 
   freezing_method:
     term:


### PR DESCRIPTION
### Improvements
The `interval of onset to death` data in GTEx are numbers with digits instead of integers. Made the change to accommodate that.
