### PR TITLE
chore/gtex_number:replace integer with number

### DIFF
--- a/gdcdictionary/schemas/death_record.yaml
+++ b/gdcdictionary/schemas/death_record.yaml
@@ -134,17 +134,17 @@ properties:
   interval_to_death_first_cause:
     description: >
       Onset to Death interval from first underlying cause of death to death (hours). (GTEx) 
-    type: integer
+    type: number
 
   interval_to_death_immediate_cause:
     description: >
       Onset to Death Interval from immediate cause of death to death (hours). (GTEx)
-    type: integer
+    type: number
 
   interval_to_death_last_cause:
     description: >
       Onset to Death Interval from last underlying cause of death to death (hours). (GTEx) 
-    type: integer
+    type: number
 
   last_cause_of_death:
     description: >
@@ -184,7 +184,7 @@ properties:
   hours_in_ventilator:
     description: >
       Period of time that donor was assisted by a medical device that facilitates breathing prior to death. (GTEx)
-    type: integer
+    type: number
 
   on_ventilator_immediate:
     description: >

--- a/gdcdictionary/schemas/exposure.yaml
+++ b/gdcdictionary/schemas/exposure.yaml
@@ -62,7 +62,7 @@ properties:
   smoke_number:
     description: >
       Units smoked during Smoke Period (SMKPRD). (GTEx)
-    type: integer
+    type: number
 
   smoke_period:
     description: >
@@ -123,7 +123,7 @@ properties:
   drink_number:
     term:
       $ref: "_terms.yaml#/drink_number"
-    type: integer
+    type: number
 
   drink_period:
     description: >
@@ -133,7 +133,7 @@ properties:
   drink_years:
     description: >
       Number of years the Donor drank. (GTEx)
-    type: integer
+    type: number
 
   drink_comments:
     description: >

--- a/gdcdictionary/schemas/medical_history.yaml
+++ b/gdcdictionary/schemas/medical_history.yaml
@@ -673,7 +673,7 @@ properties:
   chdh_time:
     description: >
       Time to hard CHD or Last Follow-up in days
-    type: integer
+    type: number
 
   chda:
     description: >
@@ -683,7 +683,7 @@ properties:
   chda_time:
     description: >
       Time to all CHD or Lat Follow-up in days
-    type: integer
+    type: number
 
   cvdh:
     description: >
@@ -693,7 +693,7 @@ properties:
   cvdh_time:
     description: >
       Time to hard CVD or Last Follow-up in days
-    type: integer
+    type: number
 
   cvda:
     description: >
@@ -703,7 +703,7 @@ properties:
   cvda_time:
     description: >
       Time to all CVD or Last Follow-up in days
-    type: integer
+    type: number
 
   prostate_cancer:
     description: >

--- a/gdcdictionary/schemas/sample.yaml
+++ b/gdcdictionary/schemas/sample.yaml
@@ -144,7 +144,7 @@ properties:
   hours_to_sample_procurement:
     description: >
       Time a sample spent in the PAXgene fixative
-    type: integer
+    type: number
 
   freezing_method:
     term:


### PR DESCRIPTION
### Bug Fixes
The `interval of onset to death` data in GTEx are numbers with digits instead of integers. Made the change to accommodate that.