### PR TITLE
chore/exposure_node:years_smoked

### DIFF
--- a/gdcdictionary/schemas/exposure.yaml
+++ b/gdcdictionary/schemas/exposure.yaml
@@ -79,8 +79,7 @@ properties:
     type:
       - number
       - "null"
-    maximum: 89
-    minimum: 0
+   
 
   years_smoked_gt89:
     term:


### PR DESCRIPTION
### Bug Fixes
remove maximum and minimum for the `years_smoked` in exposure node
