### PR TITLE
chore/fix: issues in cmg dd

### DIFF
--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -55,6 +55,11 @@ properties:
       If amputated, the amputation type for leg, above the knee or below the knee. (GTEx)
     type: string
 
+  cmg_project_id:
+    description: >
+      Information field about project/cohort. (CMG)
+    type: string
+  
   multiple_datasets:
     description: >
       Flag if an individual has data represented in multiple data types (Ex: Yes if both exome and genome data is available for an individual). (CMG)

--- a/gdcdictionary/schemas/sample.yaml
+++ b/gdcdictionary/schemas/sample.yaml
@@ -63,12 +63,12 @@ properties:
       Uberon ID, anatomical location as described by the Uber Anatomy Ontology (UBERON). (CMG)
     type: string
 
-  biospecimen_anatomic_site_uberon_label:
+  sample_source:
     description: >
       Uberon Label, anatomical location as described by the Uber Anatomy Ontology (UBERON). (CMG)
     type: string
 
-  biospecimen_provider:
+  sample_provider:
     description: >
       The name of collaborator who provides the sample. (CMG) 
     enum:


### PR DESCRIPTION
### Bug Fixes

1. The property `project_id` in the data_set cannot be used on gen3, because that is a special system property (submitted case without this information)
2. The property `sample_provider` is not in the DD. This is the one that had the enumeration for institutions and I thought we decided to use the enumeration and remove the number codes from the other data set (submitted sample without this information)
3. The property `sample_source` is not in the DD. This is another problematic enumeration, because one data set uses the UBERON code the other uses the biological term. (submitted sample without this information)
