### PR TITLE
Fix family.project_id

### DIFF
--- a/gdcdictionary/schemas/family.yaml
+++ b/gdcdictionary/schemas/family.yaml
@@ -38,6 +38,8 @@ uniqueKeys:
   - [project_id, submitter_id]
 
 properties:
+  $ref: "_definitions.yaml#/ubiquitous_properties"
+
   type:
     enum: [ "family" ]
 


### PR DESCRIPTION

### Bug Fixes
- Fix peregrine issue with "project_id" not being a valid argument for graphQL type "family"
